### PR TITLE
Some updates to future proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ target/
 local-only
 src/test/scala/daut0_experiments/
 /src/test/scala/daut37_pycontract/log_msl_timed.csv
+
+# Metals and VSCode
+.bsp/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ In the following, we shall illustrate the API by going through a collection of e
 
 There are some options:
 
-- The repository is an [SBT](https://www.scala-sbt.org) project. To run it as an SBT project you must download SBT first, and follow the instructions there on how to run SBT projects. 
+- The repository is an [SBT](https://www.scala-sbt.org) project. To run it as an SBT project you must download SBT first, and follow the instructions there on how to run SBT projects.
+
+- Use the following commands to run the tests. Each test has its own directory and main class. Type the number of the test you would like to run.
+
+  ```sh
+  $ sbt
+  sbt:daut> Test / run
+  ```
 
 - The main file is: [src/main/scala/daut/Monitor.scala](src/main/scala/daut/Monitor.scala). This source can alternatively be incorporated into your own project, fitting your own way of working, and you are up and running. One file is simplicity.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ class MyMonitor extends Monitor[SomeType] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new MyMonitor()
     m.verify(event1)
     m.verify(event2)
@@ -114,7 +114,7 @@ class AcquireRelease extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new AcquireRelease
     m.verify(acquire(1, 10))
@@ -221,7 +221,7 @@ We can now apply the monitor, as for example in the following main program:
 
 ```scala
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new AcquireRelease
     m.verify(acquire(1, 10))
     m.verify(release(1, 10))
@@ -383,7 +383,7 @@ The following main program exercises the monitor.
 
 ```scala
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new StartStop
     m.PRINT = true
     m.verify(start(0))
@@ -637,7 +637,7 @@ Finally, we can instantiate the monitor:-
 
 ```scala
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new ReleaseWithin(500) printSteps()
     m.verify(acquire(1, 10, 100))
     m.verify(release(1, 10, 800)) // violates property
@@ -722,7 +722,7 @@ class Monitors extends Monitor[Event] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new Monitors // now monitoring two sub-monitors
     m.verify(acquire(1, 10))
     m.verify(release(1, 10))
@@ -782,7 +782,7 @@ Let us apply this monitor as follows:
 
 ```scala
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new CorrectLock
     m.verify(acquire(1, 100))
     m.verify(acquire(2, 200))
@@ -928,7 +928,7 @@ if any, perform a proper action:
 
 ```scala
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new Monitors // now monitoring two sub-monitors
     m.verify(acquire(1, 10))
     m.verify(release(1, 10))
@@ -1093,7 +1093,7 @@ Finally, we can invoke `AllMonitors`:
 
 ```scala
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new AllMonitors
     m.verify(Send("ignore this message"))
     m.verify(Open)
@@ -1165,7 +1165,7 @@ Note that we have added the `label(t,x)` to the `hot` state. This will cause the
 
 ```
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new CorrectLock
     DautOptions.DEBUG = true
     m.verify(acquire(1, 100))

--- a/build.sbt
+++ b/build.sbt
@@ -4,5 +4,14 @@ version := "0.1"
 
 scalaVersion := "2.13.8"
 
+scalacOptions ++= Seq(
+  "-encoding", "utf8", // Option and arguments on same line
+  //"-Xfatal-warnings",  // Uncomment later
+  "-deprecation",
+  "-unchecked",
+  "-feature",
+  //"-Xsource:3" // one warning is an error on Scala 3
+)
+
 // libraryDependencies += "com.github.tototoshi" %% "scala-csv" % "1.3.6"
 libraryDependencies += "de.siegmar" %"fastcsv" %"1.0.1"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "daut"
 
 version := "0.1"
 
-scalaVersion := "2.13.3"
+scalaVersion := "2.13.8"
 
 // libraryDependencies += "com.github.tototoshi" %% "scala-csv" % "1.3.6"
 libraryDependencies += "de.siegmar" %"fastcsv" %"1.0.1"

--- a/src/main/scala/daut/Monitor.scala
+++ b/src/main/scala/daut/Monitor.scala
@@ -307,7 +307,7 @@ class Monitor[E] {
     * @param monitors the monitors to become sub-monitors of this monitor.
     */
 
-  def monitor(monitors: Monitor[E]*) {
+  def monitor(monitors: Monitor[E]*): Unit = {
     for (monitor <- monitors) {
       monitor.monitorAtTop = false
     }
@@ -1077,7 +1077,7 @@ class Monitor[E] {
     * @param s state to be added as initial state.
     */
 
-  protected def initial(s: state) {
+  protected def initial(s: state): Unit = {
     s.isInitial = true
     states.initial(s)
   }
@@ -1326,7 +1326,7 @@ class Monitor[E] {
     * @param event the event being verified.
     */
 
-  protected def verifyBeforeEvent(event: E) {}
+  protected def verifyBeforeEvent(event: E): Unit = {}
 
   /**
     * This method is called <b>after</b> every call of `verify(event: E)`.
@@ -1335,7 +1335,7 @@ class Monitor[E] {
     * @param event the event being verified.
     */
 
-  protected def verifyAfterEvent(event: E) {}
+  protected def verifyAfterEvent(event: E): Unit = {}
 
   /**
     * This method is called when the monitor encounters an error, be it a safety
@@ -1361,13 +1361,13 @@ class Monitor[E] {
     * Prints the current states of the monitor, and its sub-monitors.
     */
 
-  private def printStates() {
+  private def printStates(): Unit = {
     println(s"--- $monitorName:")
     println("[memory] ")
     for (s <- states.getMainStates) {
       println(s"  $s")
     }
-    println
+    println()
     for (index <- states.getIndexes) {
       println(s"[index=$index]")
       for (s <- states.getIndexedSet(index)) {
@@ -1417,7 +1417,7 @@ class Monitor[E] {
     * Updates error count.
     */
 
-  protected def reportError() {
+  protected def reportError(): Unit = {
     errorCount += 1
     println(s"$monitorName error # $errorCount")
     if (DautOptions.PRINT_ERROR_BANNER) {

--- a/src/main/scala/daut/package.scala
+++ b/src/main/scala/daut/package.scala
@@ -30,7 +30,7 @@
  * }
  *
  * object Main {
- *   def main(args: Array[String]) {
+ *   def main(args: Array[String]): Unit = {
  *     val m = new MyMonitor()
  *     m.verify(event1)
  *     m.verify(event2)

--- a/src/test/scala/daut10_map/Main.scala
+++ b/src/test/scala/daut10_map/Main.scala
@@ -99,7 +99,7 @@ class TestMonitor extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new TestMonitor
     // m.stopOnError()

--- a/src/test/scala/daut11_during/Main.scala
+++ b/src/test/scala/daut11_during/Main.scala
@@ -32,7 +32,7 @@ class TestMonitor extends Monitor[Event] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new TestMonitor
     m.verify(enter(1))

--- a/src/test/scala/daut12_new_patterns/Main.scala
+++ b/src/test/scala/daut12_new_patterns/Main.scala
@@ -50,7 +50,7 @@ class AllMonitors extends Monitor[RadioEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new AllMonitors
     m.verify(Send("ignore this message"))
     m.verify(Open)

--- a/src/test/scala/daut13_timing/Main.scala
+++ b/src/test/scala/daut13_timing/Main.scala
@@ -23,7 +23,7 @@ class AcquireRelease extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val INDEX = 100000
     DautOptions.DEBUG = false
     val m = new AcquireRelease

--- a/src/test/scala/daut14_firstorder_patterns/Main.scala
+++ b/src/test/scala/daut14_firstorder_patterns/Main.scala
@@ -35,7 +35,7 @@ class Response3[E, R1, R2](p1: PartialFunction[E, R1], p2: PartialFunction[E, R2
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m1 = new Response1[E](
       { case E1(t) => t > 100 },
       { case E2(t) => t < 200 }

--- a/src/test/scala/daut15_id_temporal/Main.scala
+++ b/src/test/scala/daut15_id_temporal/Main.scala
@@ -30,7 +30,7 @@ class AcquireRelease extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val INDEX = 1000000
     DautOptions.DEBUG = false
     val m = new AcquireRelease

--- a/src/test/scala/daut16_id_temporal/Main.scala
+++ b/src/test/scala/daut16_id_temporal/Main.scala
@@ -30,7 +30,7 @@ class OneThread extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val INDEX = 3
     DautOptions.DEBUG = true
     val m = new OneThread

--- a/src/test/scala/daut17_id_temporal/Main.scala
+++ b/src/test/scala/daut17_id_temporal/Main.scala
@@ -30,7 +30,7 @@ class LocksNotReentrant extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val INDEX = 3
     DautOptions.DEBUG = true
     val m = new LocksNotReentrant

--- a/src/test/scala/daut18_id_temporal/Main.scala
+++ b/src/test/scala/daut18_id_temporal/Main.scala
@@ -23,7 +23,7 @@ class OneLockGlobally extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val INDEX = 3
     DautOptions.DEBUG = true
     val m = new OneLockGlobally

--- a/src/test/scala/daut19_id_temporal/Main.scala
+++ b/src/test/scala/daut19_id_temporal/Main.scala
@@ -80,7 +80,7 @@ class AllMonitors extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val INDEX = 3
     DautOptions.DEBUG = true
     val m = new AllMonitors

--- a/src/test/scala/daut1_temporal/Main.scala
+++ b/src/test/scala/daut1_temporal/Main.scala
@@ -22,7 +22,7 @@ class AcquireRelease extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new AcquireRelease
     m.verify(acquire(1, 10))

--- a/src/test/scala/daut20_id_temporal/Main.scala
+++ b/src/test/scala/daut20_id_temporal/Main.scala
@@ -32,7 +32,7 @@ class AcquireRelease extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val INDEX = 3
     DautOptions.DEBUG = true
     val m = new AcquireRelease

--- a/src/test/scala/daut21_id_temporal/Main.scala
+++ b/src/test/scala/daut21_id_temporal/Main.scala
@@ -49,7 +49,7 @@ class CorrectLock extends FastLockMonitor {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new CorrectLock
     DautOptions.DEBUG = true
     m.verify(acquire(1, 100))

--- a/src/test/scala/daut22_id_temporal/Main.scala
+++ b/src/test/scala/daut22_id_temporal/Main.scala
@@ -38,7 +38,7 @@ class CorrectElevator extends UpMonitor {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new CorrectElevator
     DautOptions.DEBUG = true
     m.verify(request(100))

--- a/src/test/scala/daut23_id_temporal/Main.scala
+++ b/src/test/scala/daut23_id_temporal/Main.scala
@@ -48,7 +48,7 @@ class CorrectElevator extends ElevatorMonitor {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new CorrectElevator
     DautOptions.DEBUG = true
     m(request(1, 100))

--- a/src/test/scala/daut24_id_temporal/Main.scala
+++ b/src/test/scala/daut24_id_temporal/Main.scala
@@ -55,7 +55,7 @@ class AcquireRelease extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new TestMonitor
     m.verify(acquire(1, 100))

--- a/src/test/scala/daut25_id_temporal/Main.scala
+++ b/src/test/scala/daut25_id_temporal/Main.scala
@@ -37,7 +37,7 @@ class AcquireRelease extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new AcquireRelease
     DautOptions.DEBUG = true
     m(acquire(1, 10))

--- a/src/test/scala/daut26_nfer/Main.scala
+++ b/src/test/scala/daut26_nfer/Main.scala
@@ -202,7 +202,7 @@ class DownLinkOk7 extends Monitor[Event] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new DownLinkOk7
 

--- a/src/test/scala/daut27_init/Main.scala
+++ b/src/test/scala/daut27_init/Main.scala
@@ -16,7 +16,7 @@ class MyMonitor() extends Monitor[Event] {
     case Event(2) => Saw(2)
   }
 
-  def Init() {
+  def Init(): Unit = {
     MyFact(3)
     MyFact(4)
   }

--- a/src/test/scala/daut27_init/Main.scala
+++ b/src/test/scala/daut27_init/Main.scala
@@ -29,23 +29,25 @@ class MyMonitor() extends Monitor[Event] {
 
   case class Saw(t: Int) extends fact
 }
-object Main extends App {
-  DautOptions.DEBUG = true
+object Main {
+  def main(args: Array[String]): Unit = {
+    DautOptions.DEBUG = true
 
-  var eventStream = List[Event](
-    Event (1),
-    Event (2),
-    Event (3),
-    Event (4)
-  )
+    var eventStream = List[Event](
+      Event (1),
+      Event (2),
+      Event (3),
+      Event (4)
+    )
 
-  var req = new MyMonitor()
-  req.Init()
-  req.getAllStates foreach println // just the initial state
+    var req = new MyMonitor()
+    req.Init()
+    req.getAllStates foreach println // just the initial state
 
-  var requirements = List[MyMonitor]( req )
+    var requirements = List[MyMonitor]( req )
 
-  for (event <- eventStream) {
-    req.verify(event)
+    for (event <- eventStream) {
+      req.verify(event)
+    }
   }
 }

--- a/src/test/scala/daut28_overriding/Main.scala
+++ b/src/test/scala/daut28_overriding/Main.scala
@@ -38,21 +38,23 @@ class Fact extends Monitor[Event] {
 
 }
 
-object Main extends App {
-  val m = new Fact
-  DautOptions.DEBUG = true
+object Main {
+  def main(args: Array[String]): Unit = {
+    val m = new Fact
+    DautOptions.DEBUG = true
 
-  var eventStream = List[Event](
-    Time(0),
-    Value(0, "x", 1),
-    Value(0, "y", -1),
-    Time(1),
-    Value(1, "x", 0),
-    Value(1, "y", 0),
-    Value(8, "y", 0),
-  )
+    var eventStream = List[Event](
+      Time(0),
+      Value(0, "x", 1),
+      Value(0, "y", -1),
+      Time(1),
+      Value(1, "x", 0),
+      Value(1, "y", 0),
+      Value(8, "y", 0),
+    )
 
-  for (e <- eventStream) {
-    m.verify(e)
+    for (e <- eventStream) {
+      m.verify(e)
+    }
   }
 }

--- a/src/test/scala/daut2_statemachine/Main.scala
+++ b/src/test/scala/daut2_statemachine/Main.scala
@@ -27,7 +27,7 @@ class AcquireRelease extends Monitor[Event] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new AcquireRelease
     m.verify(acquire(1, 10))

--- a/src/test/scala/daut32_hashmaps/Main.scala
+++ b/src/test/scala/daut32_hashmaps/Main.scala
@@ -41,7 +41,7 @@ class OneThreadAtATime extends Monitor[LockEvent] {
 object Main {
   def mkLock(i:Int): LockId = i.toString
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val INDEX = 10000000
     DautOptions.DEBUG = false
     val m = new OneThreadAtATime

--- a/src/test/scala/daut33_rules/Main.scala
+++ b/src/test/scala/daut33_rules/Main.scala
@@ -37,7 +37,7 @@ class Rules extends Monitor[Event] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new Rules
     m.verify(E01(10))

--- a/src/test/scala/daut34_generic/Main.scala
+++ b/src/test/scala/daut34_generic/Main.scala
@@ -42,7 +42,7 @@ object Main {
   val traceAB = List(A(10), B(10))
   val traceAC = List(A(10), C(10))
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val gB = new Generic[B]
     val gC = new Generic[C]

--- a/src/test/scala/daut35_nokia/Main.scala
+++ b/src/test/scala/daut35_nokia/Main.scala
@@ -170,7 +170,7 @@ class BothMonitors extends Monitor[Event] {
   */
 
 object Test_Ins_1_2 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = false
     val m = new Ins_1_2
 
@@ -239,7 +239,7 @@ object Test_Ins_1_2 {
   */
 
 object Test_Del_1_2 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = false
     val m = new Del_1_2_coded
 
@@ -343,7 +343,7 @@ class FastCSVReader(fileName: String) {
   import de.siegmar.fastcsv.reader.CsvReader
   import de.siegmar.fastcsv.reader.CsvRow
   import java.nio.charset.StandardCharsets
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   val file = new File(fileName)
   val csvReader = new CsvReader
@@ -405,7 +405,7 @@ class LogReader(fileName: String) {
               case DELETE =>
                 event = Some(Delete(time, user, database, data))
             }
-            break
+            break()
           }
         }
       }

--- a/src/test/scala/daut36_nokia_shortnames/Main.scala
+++ b/src/test/scala/daut36_nokia_shortnames/Main.scala
@@ -171,7 +171,7 @@ class Monitors extends Monitor[Ev] {
   */
 
 object Test_Ins_1_2 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = false
     val m = new Ins_1_2
 
@@ -240,7 +240,7 @@ object Test_Ins_1_2 {
   */
 
 object Test_Del_1_2 {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = false
     val m = new Del_1_2_opt
 
@@ -344,7 +344,7 @@ class FastCSVReader(fileName: String) {
   import de.siegmar.fastcsv.reader.CsvReader
   import de.siegmar.fastcsv.reader.CsvRow
   import java.nio.charset.StandardCharsets
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   val file = new File(fileName)
   val csvReader = new CsvReader
@@ -400,7 +400,7 @@ class LogReader(fileName: String) {
               case INSERT => e = Some(Ins(t, u, db, d))
               case DELETE => e = Some(Del(t, u, db, d))
             }
-            break
+            break()
           }
         }
       }

--- a/src/test/scala/daut37_pycontract/Main.scala
+++ b/src/test/scala/daut37_pycontract/Main.scala
@@ -51,7 +51,7 @@ class CommandExecution extends Monitor[Event] {
 }
 
 object Test {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = false
     val m = new CommandExecution
 
@@ -84,7 +84,7 @@ class FastCSVReader(fileName: String) {
   import de.siegmar.fastcsv.reader.CsvReader
   import de.siegmar.fastcsv.reader.CsvRow
   import java.nio.charset.StandardCharsets
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   val file = new File(fileName)
   val csvReader = new CsvReader

--- a/src/test/scala/daut38_sacsvt_2022/Main.scala
+++ b/src/test/scala/daut38_sacsvt_2022/Main.scala
@@ -59,7 +59,7 @@ class FastCSVReader(fileName: String) {
   import de.siegmar.fastcsv.reader.CsvReader
   import de.siegmar.fastcsv.reader.CsvRow
   import java.nio.charset.StandardCharsets
-  import scala.collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   val file = new File(fileName)
   val csvReader = new CsvReader

--- a/src/test/scala/daut39_rv_2022/Main.scala
+++ b/src/test/scala/daut39_rv_2022/Main.scala
@@ -66,7 +66,7 @@ class M3 extends Monitor[Event] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new M3
     DautOptions.DEBUG = false
     val trace =  List(

--- a/src/test/scala/daut3_statemachine/Main.scala
+++ b/src/test/scala/daut3_statemachine/Main.scala
@@ -32,7 +32,7 @@ class StartStop extends Monitor[TaskEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new StartStop
     m.verify(start(0))

--- a/src/test/scala/daut4_rules/Main.scala
+++ b/src/test/scala/daut4_rules/Main.scala
@@ -29,7 +29,7 @@ class AcquireRelease extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new AcquireRelease
     m.verify(acquire(1, 10))
     m.verify(acquire(2, 10))

--- a/src/test/scala/daut5_rules/Main.scala
+++ b/src/test/scala/daut5_rules/Main.scala
@@ -42,7 +42,7 @@ class Monitors extends Monitor[Event] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new Monitors
     m.verify(acquire(1, 10))

--- a/src/test/scala/daut6_rules/Main.scala
+++ b/src/test/scala/daut6_rules/Main.scala
@@ -32,7 +32,7 @@ class TestMonitor extends Monitor[TaskEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new TestMonitor
     m.verify(start(0))

--- a/src/test/scala/daut7_invariants/Main.scala
+++ b/src/test/scala/daut7_invariants/Main.scala
@@ -27,7 +27,7 @@ class AcquireReleaseLimit extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     DautOptions.DEBUG = true
     val m = new AcquireReleaseLimit
     m.verify(acquire(1, 10))

--- a/src/test/scala/daut8_realtime/Main.scala
+++ b/src/test/scala/daut8_realtime/Main.scala
@@ -24,7 +24,7 @@ class ReleaseWithin(limit: Int) extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new ReleaseWithin(500)
     m.verify(acquire(1, 10, 100))
     m.verify(release(1, 10, 800)) // violates property

--- a/src/test/scala/daut9_until/Main.scala
+++ b/src/test/scala/daut9_until/Main.scala
@@ -26,7 +26,7 @@ class TestMonitor extends Monitor[LockEvent] {
 }
 
 object Main {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val m = new TestMonitor
     m.verify(acquire(1, 10))
     m.verify(release(2, 10))


### PR DESCRIPTION
- Upgrade to the latest Scala 2.13
- Add some compiler options
- Fix the low hanging deprecations
- Add some instructions for running tests

It would be nice to support Scala 3 and then work towards Scala Native support if that is a direction that you would like. I am not super familiar with the reflection and implicit errors so I didn't want to attack that especially since I am not super familiar with DSLs. Changing to Scala 3 as it is now won't compile but you can change to `3.1.3` and try it out.