### PR TITLE
Add build.properties and adjust .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,10 @@
 .metals/
 logs/
 out/
-project/
+/project/**/metals.sbt
 target/
 local-only
 /src/test/scala/daut37_pycontract/log_msl_timed.csv
 *.sh
 /src/test/scala/daut_endurance/
 /src/test/scala/experiments/
-/.bsp/sbt.json

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.2


### PR DESCRIPTION
Hi Klaus, I closed the old pull request - it looks like over time you adopted all my changes.

Here is a new one that makes sure you are using the configured `sbt` version. This is pretty important for a repeatable build in case someone else or even you changes your installed `sbt` build launcher. Even if you have an older or newer launcher, `sbt` will download the correct `sbt` version according to `build.properties` to build your project. Also, the change in the `.gitignore` will ignore any Metals configuration. Maybe you are using intelliJ.